### PR TITLE
Add edit

### DIFF
--- a/src/containers/Article/index.jsx
+++ b/src/containers/Article/index.jsx
@@ -1,9 +1,12 @@
 import React, { Component, PropTypes } from 'react';
+import { Link } from 'react-router';
 import Highlight from 'react-highlight';
-
 import { CommentList, CommentForm } from '../../components';
 import { Loading } from '../../parts';
 import { Archive, CommentAction } from '../../actions';
+import Edit from 'material-ui/svg-icons/image/edit';
+
+import style from '../../style';
 import './index.scss';
 
 export default class Article extends Component {
@@ -74,9 +77,17 @@ export default class Article extends Component {
       );
     });
 
+    const url = `/edit/${article.id}`;
+    const iconStyle = Object.assign(style.icon, style.grayTxt, style.topIcon);
+
     return (
       <div styleName='container'>
-        <h1>{article.title}</h1>
+        <div styleName='articleTitle'>
+          <h1>{article.title}</h1>
+          <Link to={url}>
+            <Edit style={iconStyle} hoverColor={style.blue} />
+          </Link>
+        </div>
         {cat}
         <div styleName='content'>
           <Highlight innerHTML>

--- a/src/containers/Article/index.jsx
+++ b/src/containers/Article/index.jsx
@@ -1,10 +1,10 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 import Highlight from 'react-highlight';
+import Edit from 'material-ui/svg-icons/image/edit';
 import { CommentList, CommentForm } from '../../components';
 import { Loading } from '../../parts';
 import { Archive, CommentAction } from '../../actions';
-import Edit from 'material-ui/svg-icons/image/edit';
 
 import style from '../../style';
 import './index.scss';

--- a/src/containers/Article/index.scss
+++ b/src/containers/Article/index.scss
@@ -1,6 +1,14 @@
 @import '../../common';
 
 .container {
+  .articleTitle {
+    h1 {
+      display: inline-block;
+      max-width: 85%;
+      margin-right: 20px;
+      vertical-align: middle;
+    }
+  }
   max-width: 800px;
   margin: 0 auto;
   .cat {


### PR DESCRIPTION
### 実装内容・要件
-  記事シングルページ内での編集ボタンの実装

### 設計
- stateのarticleから記事idを取得しEditのurlに追加する

### 編集ファイル
- src/containers/Article/index.jsx
  - リンクの追加とそれに伴いreact-routerとmaterial-uiのimport
- src/containers/Article/index.scss
  - h1に対するスタイル変更
